### PR TITLE
test(organization): add tests for organization features

### DIFF
--- a/app/Rules/OrganizationOwnerRule.php
+++ b/app/Rules/OrganizationOwnerRule.php
@@ -20,7 +20,7 @@ class OrganizationOwnerRule implements ValidationRule
 
         $organization = Organization::find($value);
 
-        if ($organization && $organization->owner_id !== $user->id) {
+        if ($organization && ($organization->owner_id !== $user->id)) {
             $fail('You do not own this organization.');
         }
     }

--- a/database/factories/OrganizationFactory.php
+++ b/database/factories/OrganizationFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Organization;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class OrganizationFactory extends Factory
+{
+    protected $model = Organization::class;
+
+    public function definition()
+    {
+        return [
+            'name' => $this->faker->company,
+            'description' => $this->faker->sentence,
+            'avatar' => config('agilis.organizations.avatars.default'),
+            'owner_id' => User::factory(),
+        ];
+    }
+}

--- a/tests/Feature/OrganizationTest.php
+++ b/tests/Feature/OrganizationTest.php
@@ -1,0 +1,115 @@
+<?php
+
+use App\Models\Organization;
+use App\Models\User;
+use Illuminate\Http\UploadedFile;
+use Laravel\Sanctum\Sanctum;
+
+it('sets the organization avatar successfully', function () {
+    $user = User::factory()->create();
+    $organization = Organization::factory()->create();
+    Sanctum::actingAs($user);
+
+    $response = $this->post("/api/organizations/{$organization->id}/avatar", [
+        'avatar' => UploadedFile::fake()->image('avatar.jpg')
+    ]);
+
+    $response->assertStatus(200);
+});
+
+it('fails to set the organization avatar with invalid data', function () {
+    $user = User::factory()->create();
+    $organization = Organization::factory()->create();
+    Sanctum::actingAs($user);
+
+    $response = $this->post("/api/organizations/{$organization->id}/avatar", [
+        'avatar' => 'not-an-image'
+    ]);
+
+    $response->assertStatus(422);
+});
+
+it('removes the organization avatar successfully', function () {
+    $user = User::factory()->create();
+    $organization = Organization::factory()->create([
+        'owner_id' => $user->id
+    ]);
+    Sanctum::actingAs($user);
+
+    $response = $this->deleteJson("/api/organizations/{$organization->id}/avatar");
+
+    $response->assertStatus(200);
+});
+
+it('retrieves a list of organizations successfully', function () {
+    $user = User::factory()->create();
+    Sanctum::actingAs($user);
+    Organization::factory()->count(5)->create();
+
+    $response = $this->getJson('/api/organizations');
+
+    $response->assertStatus(200)
+        ->assertJsonCount(5, 'data');
+});
+
+it('retrieves a specific organization successfully', function () {
+    $user = User::factory()->create();
+    $organization = Organization::factory()->create();
+    Sanctum::actingAs($user);
+
+    $response = $this->getJson("/api/organizations/{$organization->id}");
+
+    $response->assertStatus(200)
+        ->assertJson(function ($json) use ($organization) {
+            $json->where('data.id', $organization->id)
+                ->where('data.name', $organization->name);
+        });
+});
+
+it('fails to retrieve a specific organization when not authenticated', function () {
+    $organization = Organization::factory()->create();
+
+    $response = $this->getJson("/api/organizations/{$organization->id}");
+
+    $response->assertStatus(401);
+});
+
+it('fails to set the organization avatar when not authenticated', function () {
+    $organization = Organization::factory()->create();
+
+    $response = $this->post("/api/organizations/{$organization->id}/avatar", [
+        'avatar' => UploadedFile::fake()->image('avatar.jpg')
+    ]);
+
+    $response->assertStatus(401);
+});
+
+it('fails to remove the organization avatar when not authenticated', function () {
+    $organization = Organization::factory()->create();
+
+    $response = $this->deleteJson("/api/organizations/{$organization->id}/avatar");
+
+    $response->assertStatus(401);
+});
+
+it('fails to remove the organization avatar when the user is not the owner', function () {
+    $user = User::factory()->create();
+    $organization = Organization::factory()->create();
+    Sanctum::actingAs($user);
+
+    $response = $this->deleteJson("/api/organizations/{$organization->id}/avatar");
+
+    $response->assertStatus(422);
+});
+
+it('fails to set the organization avatar when the user is not the owner', function () {
+    $user = User::factory()->create();
+    $organization = Organization::factory()->create();
+    Sanctum::actingAs($user);
+
+    $response = $this->post("/api/organizations/{$organization->id}/avatar", [
+        'avatar' => UploadedFile::fake()->image('avatar.jpg')
+    ]);
+
+    $response->assertStatus(422);
+});


### PR DESCRIPTION
- Added tests for setting the organization avatar successfully.
- Added tests for failing to set the organization avatar with invalid data.
- Added tests for removing the organization avatar successfully.
- Added tests for retrieving a list of organizations successfully.
- Added tests for retrieving a specific organization successfully.
- Added tests for failing to retrieve a specific organization when not authenticated.
- Added tests for failing to set the organization avatar when not authenticated.
- Added tests for failing to remove the organization avatar when not authenticated.
- Added tests for failing to remove the organization avatar when the user is not the owner.
- Added tests for failing to set the organization avatar when the user is not the owner.